### PR TITLE
use int32_t to define int and int64_t to define long. in VC long is 3…

### DIFF
--- a/include/rabit/engine.h
+++ b/include/rabit/engine.h
@@ -183,7 +183,9 @@ enum DataType {
   kLong = 4,
   kULong = 5,
   kFloat = 6,
-  kDouble = 7
+  kDouble = 7,
+  kLongLong = 8,
+  kULongLong = 9
 };
 }  // namespace mpi
 /*!

--- a/include/rabit/rabit-inl.h
+++ b/include/rabit/rabit-inl.h
@@ -27,19 +27,19 @@ inline DataType GetType<unsigned char>(void) {
   return kUChar;
 }
 template<>
-inline DataType GetType<int32_t>(void) {
+inline DataType GetType<int>(void) {
   return kInt;
 }
 template<>
-inline DataType GetType<uint32_t>(void) {
+inline DataType GetType<unsigned int>(void) {
   return kUInt;
 }
 template<>
-inline DataType GetType<int64_t>(void) {
+inline DataType GetType<long>(void) {
   return kLong;
 }
 template<>
-inline DataType GetType<uint64_t>(void) {
+inline DataType GetType<unsigned long>(void) {
   return kULong;
 }
 template<>
@@ -49,6 +49,14 @@ inline DataType GetType<float>(void) {
 template<>
 inline DataType GetType<double>(void) {
   return kDouble;
+}
+template<>
+inline DataType GetType<long long>(void) {
+	return kLongLong;
+}
+template<>
+inline DataType GetType<unsigned long long>(void) {
+	return kULongLong;
 }
 }  // namespace mpi
 }  // namespace engine

--- a/include/rabit/rabit-inl.h
+++ b/include/rabit/rabit-inl.h
@@ -7,6 +7,7 @@
 #ifndef RABIT_RABIT_INL_H
 #define RABIT_RABIT_INL_H
 // use engine for implementation
+#include <cstdint>
 #include "./io.h"
 #include "./utils.h"
 #include "../rabit.h"
@@ -26,19 +27,19 @@ inline DataType GetType<unsigned char>(void) {
   return kUChar;
 }
 template<>
-inline DataType GetType<int>(void) {
+inline DataType GetType<int32_t>(void) {
   return kInt;
 }
 template<>
-inline DataType GetType<unsigned>(void) {
+inline DataType GetType<uint32_t>(void) {
   return kUInt;
 }
 template<>
-inline DataType GetType<long>(void) {
+inline DataType GetType<int64_t>(void) {
   return kLong;
 }
 template<>
-inline DataType GetType<unsigned long>(void) {
+inline DataType GetType<uint64_t>(void) {
   return kULong;
 }
 template<>

--- a/src/engine_mpi.cc
+++ b/src/engine_mpi.cc
@@ -110,6 +110,8 @@ inline MPI::Datatype GetType(mpi::DataType dtype) {
     case kULong: return MPI::UNSIGNED_LONG;
     case kFloat: return MPI::FLOAT;
     case kDouble: return MPI::DOUBLE;
+	case kLong: return MPI::LONG_LONG;
+	case kULong: return MPI::UNSIGNED_LONG_LONG;
   }
   utils::Error("unknown mpi::DataType");
   return MPI::CHAR;


### PR DESCRIPTION
in vc, long is just 32bit. I think it makes more sense to use int32_t to define kInt and use int64_t to define kLong