### PR TITLE
FreeBSD does not have fopen64 (as of 10.3). Detect it and replace with fopen

### DIFF
--- a/include/rabit/internal/utils.h
+++ b/include/rabit/internal/utils.h
@@ -16,7 +16,7 @@
 #include <cstdarg>
 #endif
 
-#if !defined(__GNUC__)
+#if !defined(__GNUC__) || defined(__FreeBSD__)
 #define fopen64 std::fopen
 #endif
 #ifdef _MSC_VER


### PR DESCRIPTION
FreeBSD does not include fopen64, so just checking for GNUC will not do the trick. Add one extra check.