### PR TITLE
Fix C API header compatibility with C compilers

### DIFF
--- a/include/rabit/c_api.h
+++ b/include/rabit/c_api.h
@@ -11,6 +11,7 @@
 #define RABIT_EXTERN_C extern "C"
 #include <cstdio>
 #else
+#define RABIT_EXTERN_C
 #include <stdio.h>
 #endif
 


### PR DESCRIPTION
Makes `c_api.h` compatible with C compilers - fixes `error: unknown type name 'RABIT_EXTERN_C'` error. This fix was tested on MacOS + Clang and Linux + GCC.