### PR TITLE
Add build support for cygwin

### DIFF
--- a/include/dmlc/base.h
+++ b/include/dmlc/base.h
@@ -41,7 +41,7 @@
  * \brief Wheter to print stack trace for fatal error,
  * enabled on linux when using gcc.
  */
-#if (!defined(DMLC_LOG_STACK_TRACE) && defined(__GNUC__) && !defined(__MINGW32__))
+#if (!defined(DMLC_LOG_STACK_TRACE) && defined(__GNUC__) && !defined(__MINGW32__) && !defined(__CYGWIN__))
 #define DMLC_LOG_STACK_TRACE 1
 #endif
 
@@ -162,6 +162,9 @@
 #define fopen64 std::fopen
 #endif
 #if (defined __MINGW32__) && !(defined __MINGW64__)
+#define fopen64 std::fopen
+#endif
+#if defined(__CYGWIN__)
 #define fopen64 std::fopen
 #endif
 #ifdef _MSC_VER

--- a/include/dmlc/base.h
+++ b/include/dmlc/base.h
@@ -41,7 +41,8 @@
  * \brief Wheter to print stack trace for fatal error,
  * enabled on linux when using gcc.
  */
-#if (!defined(DMLC_LOG_STACK_TRACE) && defined(__GNUC__) && !defined(__MINGW32__) && !defined(__CYGWIN__))
+#if (!defined(DMLC_LOG_STACK_TRACE) && defined(__GNUC__) && !defined(__MINGW32__) \
+    && !defined(__CYGWIN__))
 #define DMLC_LOG_STACK_TRACE 1
 #endif
 

--- a/include/rabit/internal/utils.h
+++ b/include/rabit/internal/utils.h
@@ -16,7 +16,7 @@
 #include <cstdarg>
 #endif
 
-#if !defined(__GNUC__) || defined(__FreeBSD__)
+#if !defined(__GNUC__) || defined(__FreeBSD__) || defined(__CYGWIN__)
 #define fopen64 std::fopen
 #endif
 #ifdef _MSC_VER


### PR DESCRIPTION
1. use `std::fopen` instead of `fopen64` under cygwin
2. turn off `DMLC_LOG_STACK_TRACE` under cygwin to fix error: "execinfo.h: No such file or directory"