### PR TITLE
Use -msse2 flag depending upon architecure while compiling the rabit code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,16 @@ endif
 export WARNFLAGS= -Wall -Wextra -Wno-unused-parameter -Wno-unknown-pragmas -std=c++0x
 export CFLAGS = -O3 $(WARNFLAGS)
 
+#----------------------------
+# Settings for power and arm arch
+#----------------------------
+ARCH := $(shell uname -a)
+ifneq (,$(filter $(ARCH), powerpc64le ppc64le ))
+	USE_SSE=0
+else
+	USE_SSE=1
+endif
+
 ifndef USE_SSE
 	USE_SSE = 1
 endif


### PR DESCRIPTION
Hi ,

With reference to defect-  https://github.com/dmlc/rabit/issues/48
I have updated the code not to use SSE flag for ppc64 architectures. Updated code build successfully on ppc64le & x86 both architectures.

Thanks,
Snehlata Mohite.
