### PR TITLE
Add option to fail gracefull on Rabit::Init failure

### DIFF
--- a/doc/guide.md
+++ b/doc/guide.md
@@ -25,7 +25,9 @@ using namespace rabit;
 const int N = 3;
 int main(int argc, char *argv[]) {
   int a[N];
-  rabit::Init(argc, argv);
+  if (!rabit::Init(argc, argv)) {
+    return -1;
+  }
   for (int i = 0; i < N; ++i) {
     a[i] = rabit::GetRank() + i;
   }
@@ -92,7 +94,9 @@ node 0 to all other nodes.
 using namespace rabit;
 const int N = 3;
 int main(int argc, char *argv[]) {
-  rabit::Init(argc, argv);
+  if (!rabit::Init(argc, argv)) {
+    return -1;
+  }
   std::string s;
   if (rabit::GetRank() == 0) s = "hello world";
   printf("@node[%d] before-broadcast: s=\"%s\"\n",
@@ -153,7 +157,9 @@ you can also refer to [wormhole](https://github.com/dmlc/wormhole/blob/master/le
 #include <rabit.h>
 int main(int argc, char *argv[]) {
   ...
-  rabit::Init(argc, argv);
+  if (!rabit::Init(argc, argv)) {
+    return -1;
+  }
   // load the latest checked model
   int version = rabit::LoadCheckPoint(&model);
   // initialize the model if it is the first version
@@ -206,7 +212,9 @@ using namespace rabit;
 const int N = 3;
 int main(int argc, char *argv[]) {
   int a[N] = {0};
-  rabit::Init(argc, argv);
+  if (!rabit::Init(argc, argv)) {
+    return -1;
+  }
   // lazy preparation function
   auto prepare = [&]() {
     printf("@node[%d] run prepare function\n", rabit::GetRank());

--- a/guide/basic.cc
+++ b/guide/basic.cc
@@ -16,7 +16,9 @@ int main(int argc, char *argv[]) {
     N = atoi(argv[1]);
   }
   std::vector<int> a(N);
-  rabit::Init(argc, argv);
+  if (!rabit::Init(argc, argv)) {
+    return -1;
+  }
   for (int i = 0; i < N; ++i) {
     a[i] = rabit::GetRank() + i;
   }

--- a/guide/broadcast.cc
+++ b/guide/broadcast.cc
@@ -2,7 +2,9 @@
 using namespace rabit;
 const int N = 3;
 int main(int argc, char *argv[]) {
-  rabit::Init(argc, argv);
+  if (!rabit::Init(argc, argv)) {
+    return -1;
+  }
   std::string s;
   if (rabit::GetRank() == 0) s = "hello world";
   printf("@node[%d] before-broadcast: s=\"%s\"\n",

--- a/guide/lazy_allreduce.cc
+++ b/guide/lazy_allreduce.cc
@@ -11,7 +11,9 @@ using namespace rabit;
 const int N = 3;
 int main(int argc, char *argv[]) {
   int a[N] = {0};
-  rabit::Init(argc, argv);
+  if (!rabit::Init(argc, argv)) {
+    return -1;
+  }
   // lazy preparation function
   auto prepare = [&]() {
     printf("@node[%d] run prepare function\n", rabit::GetRank());

--- a/include/rabit/c_api.h
+++ b/include/rabit/c_api.h
@@ -32,8 +32,9 @@ typedef unsigned long rbt_ulong;  // NOLINT(*)
  *  from environment variables.
  * \param argc number of arguments in argv
  * \param argv the array of input arguments
+ * \return true on successfull init. May also exit(-1).
  */
-RABIT_DLL void RabitInit(int argc, char *argv[]);
+RABIT_DLL bool RabitInit(int argc, char *argv[]);
 
 /*!
  * \brief finalize the rabit engine,

--- a/include/rabit/internal/engine.h
+++ b/include/rabit/internal/engine.h
@@ -161,7 +161,7 @@ class IEngine {
 };
 
 /*! \brief initializes the engine module */
-void Init(int argc, char *argv[]);
+bool Init(int argc, char *argv[]);
 /*! \brief finalizes the engine module */
 void Finalize(void);
 /*! \brief singleton method to get engine */

--- a/include/rabit/internal/rabit-inl.h
+++ b/include/rabit/internal/rabit-inl.h
@@ -103,8 +103,8 @@ inline void Reducer(const void *src_, void *dst_, int len, const MPI::Datatype &
 }  // namespace op
 
 // intialize the rabit engine
-inline void Init(int argc, char *argv[]) {
-  engine::Init(argc, argv);
+inline bool Init(int argc, char *argv[]) {
+  return engine::Init(argc, argv);
 }
 // finalize the rabit engine
 inline void Finalize(void) {

--- a/include/rabit/rabit.h
+++ b/include/rabit/rabit.h
@@ -73,8 +73,9 @@ struct BitOR;
  * \brief initializes rabit, call this once at the beginning of your program
  * \param argc number of arguments in argv
  * \param argv the array of input arguments
+ * \return true on successfull init. May also exit(-1).
  */
-inline void Init(int argc, char *argv[]);
+inline bool Init(int argc, char *argv[]);
 /*!
  * \brief finalizes the rabit engine, call this function after you finished with all the jobs
  */

--- a/python/rabit.py
+++ b/python/rabit.py
@@ -103,7 +103,8 @@ def init(args=None, lib='standard', lib_dll=None):
     _loadlib(lib, lib_dll)
     arr = (ctypes.c_char_p * len(args))()
     arr[:] = args
-    _LIB.RabitInit(len(args), arr)
+    if not _LIB.RabitInit(len(args), arr):
+      raise Error("Failed to initialize rabit")
 
 def finalize():
     """Finalize the rabit engine.

--- a/src/allreduce_base.h
+++ b/src/allreduce_base.h
@@ -13,6 +13,7 @@
 #define RABIT_ALLREDUCE_BASE_H_
 
 #include <vector>
+#include <utility>
 #include <string>
 #include <algorithm>
 #include "../include/rabit/internal/utils.h"
@@ -38,7 +39,7 @@ class AllreduceBase : public IEngine {
   AllreduceBase(void);
   virtual ~AllreduceBase(void) {}
   // initialize the manager
-  virtual void Init(int argc, char* argv[]);
+  virtual bool Init(int argc, char* argv[]);
   // shutdown the engine
   virtual void Shutdown(void);
   /*!
@@ -363,13 +364,13 @@ class AllreduceBase : public IEngine {
    * \brief initialize connection to the tracker
    * \return a socket that initializes the connection
    */
-  utils::TCPSocket ConnectTracker(void) const;
+  std::pair<utils::TCPSocket, bool> ConnectTracker(const bool dieOnError = true) const;
   /*!
    * \brief connect to the tracker to fix the the missing links
    *   this function is also used when the engine start up
    * \param cmd possible command to sent to tracker
    */
-  void ReConnectLinks(const char *cmd = "start");
+  bool ReConnectLinks(const char *cmd = "start", bool dieOnError = true);
   /*!
    * \brief perform in-place allreduce, on sendrecvbuf, this function can fail, and will return the cause of failure
    *
@@ -521,6 +522,8 @@ class AllreduceBase : public IEngine {
   int world_size;
   // connect retry time
   int connect_retry;
+  // die with exit(-1) if we fail init
+  bool die_on_init;
 };
 }  // namespace engine
 }  // namespace rabit

--- a/src/allreduce_robust.cc
+++ b/src/allreduce_robust.cc
@@ -31,13 +31,16 @@ AllreduceRobust::AllreduceRobust(void) {
   env_vars.push_back("rabit_global_replica");
   env_vars.push_back("rabit_local_replica");
 }
-void AllreduceRobust::Init(int argc, char* argv[]) {
-  AllreduceBase::Init(argc, argv);
+bool AllreduceRobust::Init(int argc, char* argv[]) {
+  if (!AllreduceBase::Init(argc, argv)) {
+    return false;
+  }
   if (num_global_replica == 0) {
     result_buffer_round = -1;
   } else {
     result_buffer_round = std::max(world_size / num_global_replica, 1);
   }
+  return true;
 }
 /*! \brief shutdown the engine */
 void AllreduceRobust::Shutdown(void) {

--- a/src/allreduce_robust.h
+++ b/src/allreduce_robust.h
@@ -24,7 +24,7 @@ class AllreduceRobust : public AllreduceBase {
   AllreduceRobust(void);
   virtual ~AllreduceRobust(void) {}
   // initialize the manager
-  virtual void Init(int argc, char* argv[]);
+  virtual bool Init(int argc, char* argv[]);
   /*! \brief shutdown the engine */
   virtual void Shutdown(void);
   /*!

--- a/src/c_api.cc
+++ b/src/c_api.cc
@@ -162,8 +162,8 @@ struct WriteWrapper : public Serializable {
 }  // namespace c_api
 }  // namespace rabit
 
-void RabitInit(int argc, char *argv[]) {
-  rabit::Init(argc, argv);
+bool RabitInit(int argc, char *argv[]) {
+  return rabit::Init(argc, argv);
 }
 
 void RabitFinalize() {

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -43,13 +43,13 @@ struct ThreadLocalEntry {
 typedef ThreadLocalStore<ThreadLocalEntry> EngineThreadLocal;
 
 /*! \brief intiialize the synchronization module */
-void Init(int argc, char *argv[]) {
+bool Init(int argc, char *argv[]) {
   ThreadLocalEntry* e = EngineThreadLocal::Get();
   utils::Check(e->engine.get() == nullptr,
                "rabit::Init is already called in this thread");
   e->initialized = true;
   e->engine.reset(new Manager());
-  e->engine->Init(argc, argv);
+  return e->engine->Init(argc, argv);
 }
 
 /*! \brief finalize syncrhonization module */

--- a/src/engine_empty.cc
+++ b/src/engine_empty.cc
@@ -77,7 +77,8 @@ class EmptyEngine : public IEngine {
 EmptyEngine manager;
 
 /*! \brief intiialize the synchronization module */
-void Init(int argc, char *argv[]) {
+bool Init(int argc, char *argv[]) {
+  return true;
 }
 /*! \brief finalize syncrhonization module */
 void Finalize(void) {

--- a/src/engine_mpi.cc
+++ b/src/engine_mpi.cc
@@ -86,8 +86,9 @@ class MPIEngine : public IEngine {
 MPIEngine manager;
 
 /*! \brief intiialize the synchronization module */
-void Init(int argc, char *argv[]) {
+bool Init(int argc, char *argv[]) {
   MPI::Init(argc, argv);
+  return true;
 }
 /*! \brief finalize syncrhonization module */
 void Finalize(void) {

--- a/test/lazy_recover.cc
+++ b/test/lazy_recover.cc
@@ -89,7 +89,9 @@ int main(int argc, char *argv[]) {
     return 0;
   }
   int n = atoi(argv[1]);
-  rabit::Init(argc, argv);
+  if (!rabit::Init(argc, argv)) {
+      return -1;
+  }
   int rank = rabit::GetRank();
   int nproc = rabit::GetWorldSize();
   std::string name = rabit::GetProcessorName();

--- a/test/local_recover.cc
+++ b/test/local_recover.cc
@@ -100,7 +100,9 @@ int main(int argc, char *argv[]) {
     return 0;
   }
   int n = atoi(argv[1]);
-  rabit::Init(argc, argv);
+  if (!rabit::Init(argc, argv)) {
+    return -1;
+  }
   int rank = rabit::GetRank();
   int nproc = rabit::GetWorldSize();
   std::string name = rabit::GetProcessorName();

--- a/test/model_recover.cc
+++ b/test/model_recover.cc
@@ -90,7 +90,9 @@ int main(int argc, char *argv[]) {
     return 0;
   }
   int n = atoi(argv[1]);
-  rabit::Init(argc, argv);
+  if (!rabit::Init(argc, argv)) {
+    return -1;
+  }
   int rank = rabit::GetRank();
   int nproc = rabit::GetWorldSize();
   std::string name = rabit::GetProcessorName();

--- a/test/speed_test.cc
+++ b/test/speed_test.cc
@@ -77,7 +77,9 @@ int main(int argc, char *argv[]) {
   int n = atoi(argv[1]);
   int nrep = atoi(argv[2]);
   utils::Check(nrep >= 1, "need to at least repeat running once");
-  rabit::Init(argc, argv);
+  if (!rabit::Init(argc, argv)) {
+    return -1;
+  }
   //int rank = rabit::GetRank();
   int nproc = rabit::GetWorldSize();
   std::string name = rabit::GetProcessorName();


### PR DESCRIPTION
When running xgboost4j-spark the process that rabit
is initialized in has other things going on, such as
caches of data that is expensive to recompute. On
the rare occasion that rabit fails to connect to the
tracker rabit performs an exit(-1) which throws away
everything that was going on in the application.

It would be nice to somehow provide explicit failure
handling everywhere, but changing the external api
to that level would be quite a large breaking change.
This patch takes a very targeted approach changing
only the Init call to return a boolean indicating
success. This is disabled by default and must be
provided as part of the initialization parameters.