### PR TITLE
Don't define DMLC_LOG_STACK_TRACE on Solaris

### DIFF
--- a/include/dmlc/base.h
+++ b/include/dmlc/base.h
@@ -41,7 +41,9 @@
  * \brief Wheter to print stack trace for fatal error,
  * enabled on linux when using gcc.
  */
-#if (!defined(DMLC_LOG_STACK_TRACE) && defined(__GNUC__) && !defined(__MINGW32__))
+#if (!defined(DMLC_LOG_STACK_TRACE) \
+     && defined(__GNUC__) && !defined(__MINGW32__) \
+     && !defined(__sun) && !defined(__SVR4))
 #define DMLC_LOG_STACK_TRACE 1
 #endif
 


### PR DESCRIPTION
DMLC_LOG_STACK_TRACE involves use of non-standard header execinfo.h, which causes compilation failure on Solaris.