### PR TITLE
Try fixing mingw build error when using CMake.

### DIFF
--- a/src/allreduce_base.cc
+++ b/src/allreduce_base.cc
@@ -207,11 +207,11 @@ utils::TCPSocket AllreduceBase::ConnectTracker(void) const {
         utils::Socket::Error("Connect");
       } else {
         fprintf(stderr, "retry connect to ip(retry time %d): [%s]\n", retry, tracker_uri.c_str());
-        #ifdef _MSC_VER
+#if defined(_MSC_VER) || defined (__MINGW32__)
         Sleep(retry << 1);
-        #else
+#else
         sleep(retry << 1);
-        #endif
+#endif
         continue;
       }
     }

--- a/src/allreduce_robust.cc
+++ b/src/allreduce_robust.cc
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (c) 2014 by Contributors
+ *  Copyright (c) 2014-2018 by Contributors
  * \file allreduce_robust.cc
  * \brief Robust implementation of Allreduce
  *
@@ -53,7 +53,7 @@ void AllreduceRobust::Shutdown(void) {
 #ifdef __APPLE__
   // In OSX, one worker shutdowns and closes sockets while rest still run kCheckAck
   // This cause rest workers checkandrecover and hang inf, https://github.com/dmlc/xgboost/pull/3818
-  // TODO: a fundamental fix for this
+  // TODO(Chen Qin): a fundamental fix for this
   sleep(2);
 #endif
   AllreduceBase::Shutdown();

--- a/src/socket.h
+++ b/src/socket.h
@@ -28,8 +28,11 @@
 #include <unordered_map>
 #include "../include/rabit/internal/utils.h"
 
-#if defined(_WIN32)
+#if defined(_WIN32) && not defined(__MINGW32__)
 typedef int ssize_t;
+#endif
+
+#if defined(_WIN32)
 typedef int sock_size_t;
 
 static inline int poll(struct pollfd *pfd, int nfds,


### PR DESCRIPTION
* Check __MINGW32__ .


I tried to use `CMakeLists.txt` from `rabit` in `XGBoost` by calling `add_subdirectory`, but the build failed on mingw.  I'm not sure this will fix it since I don't have mingw currently for testing.  Please close this if there's a better solution. :)

Here is the build log:
https://ci.appveyor.com/project/tqchen/xgboost/builds/21295997/job/lip9i83alwamavv5