### PR TITLE
[rabit improvement] support rabit worker set/get configs from tracker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.3)
 
-project(rabit VERSION 0.2.0)
+project(rabit VERSION 0.2.1)
 
 option(RABIT_BUILD_TESTS "Build rabit tests" OFF)
 option(RABIT_BUILD_MPI "Build MPI" OFF)
-option(RABIT_BUILD_DMLC "Include DMLC_CORE in build" ON)
+option(RABIT_BUILD_DMLC "Include DMLC_CORE in build" OFF)
 
 add_library(rabit src/allreduce_base.cc src/allreduce_robust.cc src/engine.cc src/c_api.cc)
 add_library(rabit_base src/allreduce_base.cc src/engine_base.cc src/c_api.cc)

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ else
 endif
 
 export WARNFLAGS= -Wall -Wextra -Wno-unused-parameter -Wno-unknown-pragmas -std=c++11
-export CFLAGS = -O3 $(WARNFLAGS) -I $(DMLC)/include -I include/
+export CFLAGS = -O3 -g $(WARNFLAGS) -I $(DMLC)/include -I include/
 export LDFLAGS =-Llib
 
 #download mpi

--- a/include/rabit/c_api.h
+++ b/include/rabit/c_api.h
@@ -84,7 +84,8 @@ RABIT_DLL void RabitGetProcessorName(char *out_name,
  * \param root the root of process
  */
 RABIT_DLL void RabitBroadcast(void *sendrecv_data,
-                              rbt_ulong size, int root);
+                              rbt_ulong size, int root,
+                              const char* caller = __builtin_FUNCTION());
 /*!
  * \brief perform in-place allreduce, on sendrecvbuf
  *        this function is NOT thread-safe
@@ -108,7 +109,8 @@ RABIT_DLL void RabitAllreduce(void *sendrecvbuf,
                               int enum_dtype,
                               int enum_op,
                               void (*prepare_fun)(void *arg),
-                              void *prepare_arg);
+                              void *prepare_arg, 
+                              const char* caller = __builtin_FUNCTION());
 
 /*!
  * \brief load latest check point

--- a/include/rabit/internal/engine.h
+++ b/include/rabit/internal/engine.h
@@ -158,8 +158,8 @@ class IEngine {
    * \param msg message to be printed in the tracker
    */
   virtual void TrackerPrint(const std::string &msg) = 0;
-  virtual void TrackerSetConfig(const std::string &key, const std::string &value) = 0;
-  virtual void TrackerGetConfig(const std::string& key, std::string* value) = 0;
+  virtual void TrackerSetConfig(const std::string &key, const int size, const void* value) = 0;
+  virtual void TrackerGetConfig(const std::string& key, const int size, void* value) = 0;
 };
 
 /*! \brief initializes the engine module */

--- a/include/rabit/internal/engine.h
+++ b/include/rabit/internal/engine.h
@@ -158,8 +158,8 @@ class IEngine {
    * \param msg message to be printed in the tracker
    */
   virtual void TrackerPrint(const std::string &msg) = 0;
-  virtual void TrackerSetConfig(const std::string &key, const int size, const void* value) = 0;
-  virtual void TrackerGetConfig(const std::string& key, const int size, void* value) = 0;
+  virtual void TrackerSetConfig(const std::string &key, const std::string &value) = 0;
+  virtual void TrackerGetConfig(const std::string& key, std::string* value) = 0;
 };
 
 /*! \brief initializes the engine module */

--- a/include/rabit/internal/engine.h
+++ b/include/rabit/internal/engine.h
@@ -158,6 +158,8 @@ class IEngine {
    * \param msg message to be printed in the tracker
    */
   virtual void TrackerPrint(const std::string &msg) = 0;
+  virtual void TrackerSetConfig(const std::string &key, const std::string &value) = 0;
+  virtual void TrackerGetConfig(const std::string& key, std::string* value) = 0;
 };
 
 /*! \brief initializes the engine module */

--- a/include/rabit/internal/rabit-inl.h
+++ b/include/rabit/internal/rabit-inl.h
@@ -197,6 +197,38 @@ inline void TrackerPrintf(const char *fmt, ...) {
   msg.resize(strlen(msg.c_str()));
   TrackerPrint(msg);
 }
+
+inline void TrackerSetConfig(const char *key, const char *value, ...) {
+  const int kPrintBuffer = 1 << 10;
+  std::string k(kPrintBuffer, '\0'), v(kPrintBuffer, '\0');
+
+  va_list args1, args2;
+  va_start(args1, key);
+  va_start(args2, value);
+  vsnprintf(&k[0], kPrintBuffer, key, args1);
+  vsnprintf(&v[0], kPrintBuffer, value, args2);
+  va_end(args1);
+  va_end(args2);
+  k.resize(strlen(k.c_str()));
+  v.resize(strlen(v.c_str()));
+  engine::GetEngine()->TrackerSetConfig(k, v);
+}
+
+inline void TrackerGetConfig(const char *key, char* value, ...) {
+  const int kPrintBuffer = 1 << 10;
+  std::string k(kPrintBuffer, '\0'), v(kPrintBuffer, '\0');
+
+  va_list args1, args2;
+  va_start(args1, key);
+  va_start(args2, value);
+  vsnprintf(&k[0], kPrintBuffer, key, args1);
+  vsnprintf(&v[0], kPrintBuffer, value, args2);
+  va_end(args1);
+  va_end(args2);
+  k.resize(strlen(k.c_str()));
+  v.resize(strlen(v.c_str()));
+  engine::GetEngine()->TrackerGetConfig(k, &v);
+}
 #endif  // RABIT_STRICT_CXX98_
 // load latest check point
 inline int LoadCheckPoint(Serializable *global_model,

--- a/include/rabit/internal/rabit-inl.h
+++ b/include/rabit/internal/rabit-inl.h
@@ -127,29 +127,28 @@ inline std::string GetProcessorName(void) {
   return engine::GetEngine()->GetHost();
 }
 // broadcast data to all other nodes from root
-inline void Broadcast(void *sendrecv_data, size_t size, int root, const char* caller) {
-  utils::Printf("[%d] Broadcast caller is %s \n", GetRank(), caller);
+inline void Broadcast(void *sendrecv_data, size_t size, int root) {
   engine::GetEngine()->Broadcast(sendrecv_data, size, root);
 }
 template<typename DType>
-inline void Broadcast(std::vector<DType> *sendrecv_data, int root, const char* caller) {
+inline void Broadcast(std::vector<DType> *sendrecv_data, int root) {
   size_t size = sendrecv_data->size();
   Broadcast(&size, sizeof(size), root);
   if (sendrecv_data->size() != size) {
     sendrecv_data->resize(size);
   }
   if (size != 0) {
-    Broadcast(&(*sendrecv_data)[0], size * sizeof(DType), root, caller);
+    Broadcast(&(*sendrecv_data)[0], size * sizeof(DType), root);
   }
 }
-inline void Broadcast(std::string *sendrecv_data, int root, const char* caller) {
+inline void Broadcast(std::string *sendrecv_data, int root) {
   size_t size = sendrecv_data->length();
-  Broadcast(&size, sizeof(size), root, caller);
+  Broadcast(&size, sizeof(size), root);
   if (sendrecv_data->length() != size) {
     sendrecv_data->resize(size);
   }
   if (size != 0) {
-    Broadcast(&(*sendrecv_data)[0], size * sizeof(char), root, caller);
+    Broadcast(&(*sendrecv_data)[0], size * sizeof(char), root);
   }
 }
 
@@ -157,9 +156,7 @@ inline void Broadcast(std::string *sendrecv_data, int root, const char* caller) 
 template<typename OP, typename DType>
 inline void Allreduce(DType *sendrecvbuf, size_t count,
                       void (*prepare_fun)(void *arg),
-                      void *prepare_arg, 
-                      const char* caller) {
-  utils::Printf("[%d] Allreduce caller is %s \n", GetRank(), caller);
+                      void *prepare_arg) {
   engine::Allreduce_(sendrecvbuf, sizeof(DType), count, op::Reducer<OP, DType>,
                      engine::mpi::GetType<DType>(), OP::kType, prepare_fun, prepare_arg);
 }
@@ -170,8 +167,7 @@ inline void InvokeLambda_(void *fun) {
   (*static_cast<std::function<void()>*>(fun))();
 }
 template<typename OP, typename DType>
-inline void Allreduce(DType *sendrecvbuf, size_t count, std::function<void()> prepare_fun, const char* caller) {
-  utils::Printf("[%d] Allreduce caller is %s \n", GetRank(), caller);
+inline void Allreduce(DType *sendrecvbuf, size_t count, std::function<void()> prepare_fun) {
   engine::Allreduce_(sendrecvbuf, sizeof(DType), count, op::Reducer<OP, DType>,
                      engine::mpi::GetType<DType>(), OP::kType, InvokeLambda_, &prepare_fun);
 }
@@ -292,7 +288,7 @@ inline Reducer<DType, freduce>::Reducer(void) {
 template<typename DType, void (*freduce)(DType &dst, const DType &src)> // NOLINT(*)
 inline void Reducer<DType, freduce>::Allreduce(DType *sendrecvbuf, size_t count,
                                                void (*prepare_fun)(void *arg),
-                                               void *prepare_arg, const char* caller) {
+                                               void *prepare_arg) {
   handle_.Allreduce(sendrecvbuf, sizeof(DType), count, prepare_fun, prepare_arg);
 }
 // function to perform reduction for SerializeReducer
@@ -341,9 +337,7 @@ template<typename DType>
 inline void SerializeReducer<DType>::Allreduce(DType *sendrecvobj,
                                                size_t max_nbyte, size_t count,
                                                void (*prepare_fun)(void *arg),
-                                               void *prepare_arg,
-                                               const char* caller) {
-  utils::Printf("[%d] Allreduce caller is %s \n", GetRank(), caller);
+                                               void *prepare_arg) {
   buffer_.resize(max_nbyte * count);
   // setup closure
   SerializeReduceClosure<DType> c;
@@ -361,17 +355,13 @@ inline void SerializeReducer<DType>::Allreduce(DType *sendrecvobj,
 #if DMLC_USE_CXX11
 template<typename DType, void (*freduce)(DType &dst, const DType &src)>  // NOLINT(*)g
 inline void Reducer<DType, freduce>::Allreduce(DType *sendrecvbuf, size_t count,
-                                               std::function<void()> prepare_fun,
-                                               const char* caller) {
-  utils::Printf("[%d] Allreduce caller is %s \n", GetRank(), caller);
+                                               std::function<void()> prepare_fun) {
   this->Allreduce(sendrecvbuf, count, InvokeLambda_, &prepare_fun);
 }
 template<typename DType>
 inline void SerializeReducer<DType>::Allreduce(DType *sendrecvobj,
                                                size_t max_nbytes, size_t count,
-                                               std::function<void()> prepare_fun,
-                                               const char* caller) {
-  utils::Printf("[%d] Allreduce caller is %s \n", GetRank(), caller);
+                                               std::function<void()> prepare_fun) {
   this->Allreduce(sendrecvobj, max_nbytes, count, InvokeLambda_, &prepare_fun);
 }
 #endif  // DMLC_USE_CXX11

--- a/include/rabit/internal/rabit-inl.h
+++ b/include/rabit/internal/rabit-inl.h
@@ -142,7 +142,8 @@ inline void Broadcast(std::vector<DType> *sendrecv_data, int root, const char* c
     Broadcast(&(*sendrecv_data)[0], size * sizeof(DType), root, caller);
   }
 }
-inline void Broadcast(std::string *sendrecv_data, int root, const char* caller) {
+inline void Broadcast(std::string *sendrecv_data, int root, 
+  const char* caller) {
   size_t size = sendrecv_data->length();
   Broadcast(&size, sizeof(size), root, caller);
   if (sendrecv_data->length() != size) {
@@ -182,12 +183,12 @@ inline void TrackerPrint(const std::string &msg) {
   engine::GetEngine()->TrackerPrint(msg);
 }
 
-inline void TrackerSetConfig(const std::string &key, const std::string &value) {
-  engine::GetEngine()->TrackerSetConfig(key, value);
+inline void TrackerSetConfig(const std::string &key, const int bsize, const void *value) {
+  engine::GetEngine()->TrackerSetConfig(key, bsize, value);
 }
 
-inline void TrackerGetConfig(const std::string &key, std::string* value) {
-  engine::GetEngine()->TrackerGetConfig(key, value);
+inline void TrackerGetConfig(const std::string &key, const int bsize, void *value) {
+  engine::GetEngine()->TrackerGetConfig(key, bsize, value);
 }
 
 #ifndef RABIT_STRICT_CXX98_
@@ -202,7 +203,7 @@ inline void TrackerPrintf(const char *fmt, ...) {
   TrackerPrint(msg);
 }
 
-inline void TrackerSetConfig(const char *key, const char *value, ...) {
+inline void TrackerSetConfig(const char *key, const int bsize, const void *value, ...) {
   const int kPrintBuffer = 1 << 10;
   std::string k(kPrintBuffer, '\0'), v(kPrintBuffer, '\0');
 
@@ -210,28 +211,22 @@ inline void TrackerSetConfig(const char *key, const char *value, ...) {
   va_start(args1, key);
   va_start(args2, value);
   vsnprintf(&k[0], kPrintBuffer, key, args1);
-  vsnprintf(&v[0], kPrintBuffer, value, args2);
   va_end(args1);
   va_end(args2);
   k.resize(strlen(k.c_str()));
-  v.resize(strlen(v.c_str()));
-  engine::GetEngine()->TrackerSetConfig(k, v);
+  engine::GetEngine()->TrackerSetConfig(k, bsize, value);
 }
 
-inline void TrackerGetConfig(const char *key, char* value, ...) {
+inline void TrackerGetConfig(const char *key, const int bsize, void* value, ...) {
   const int kPrintBuffer = 1 << 10;
   std::string k(kPrintBuffer, '\0'), v(kPrintBuffer, '\0');
 
-  va_list args1, args2;
+  va_list args1;
   va_start(args1, key);
-  va_start(args2, value);
   vsnprintf(&k[0], kPrintBuffer, key, args1);
-  vsnprintf(&v[0], kPrintBuffer, value, args2);
   va_end(args1);
-  va_end(args2);
   k.resize(strlen(k.c_str()));
-  v.resize(strlen(v.c_str()));
-  engine::GetEngine()->TrackerGetConfig(k, &v);
+  engine::GetEngine()->TrackerGetConfig(k, bsize, value);
 }
 #endif  // RABIT_STRICT_CXX98_
 // load latest check point

--- a/include/rabit/internal/rabit-inl.h
+++ b/include/rabit/internal/rabit-inl.h
@@ -127,28 +127,29 @@ inline std::string GetProcessorName(void) {
   return engine::GetEngine()->GetHost();
 }
 // broadcast data to all other nodes from root
-inline void Broadcast(void *sendrecv_data, size_t size, int root) {
+inline void Broadcast(void *sendrecv_data, size_t size, int root, const char* caller) {
+  utils::Printf("[%d] Broadcast caller is %s \n", GetRank(), caller);
   engine::GetEngine()->Broadcast(sendrecv_data, size, root);
 }
 template<typename DType>
-inline void Broadcast(std::vector<DType> *sendrecv_data, int root) {
+inline void Broadcast(std::vector<DType> *sendrecv_data, int root, const char* caller) {
   size_t size = sendrecv_data->size();
   Broadcast(&size, sizeof(size), root);
   if (sendrecv_data->size() != size) {
     sendrecv_data->resize(size);
   }
   if (size != 0) {
-    Broadcast(&(*sendrecv_data)[0], size * sizeof(DType), root);
+    Broadcast(&(*sendrecv_data)[0], size * sizeof(DType), root, caller);
   }
 }
-inline void Broadcast(std::string *sendrecv_data, int root) {
+inline void Broadcast(std::string *sendrecv_data, int root, const char* caller) {
   size_t size = sendrecv_data->length();
-  Broadcast(&size, sizeof(size), root);
+  Broadcast(&size, sizeof(size), root, caller);
   if (sendrecv_data->length() != size) {
     sendrecv_data->resize(size);
   }
   if (size != 0) {
-    Broadcast(&(*sendrecv_data)[0], size * sizeof(char), root);
+    Broadcast(&(*sendrecv_data)[0], size * sizeof(char), root, caller);
   }
 }
 
@@ -156,7 +157,9 @@ inline void Broadcast(std::string *sendrecv_data, int root) {
 template<typename OP, typename DType>
 inline void Allreduce(DType *sendrecvbuf, size_t count,
                       void (*prepare_fun)(void *arg),
-                      void *prepare_arg) {
+                      void *prepare_arg, 
+                      const char* caller) {
+  utils::Printf("[%d] Allreduce caller is %s \n", GetRank(), caller);
   engine::Allreduce_(sendrecvbuf, sizeof(DType), count, op::Reducer<OP, DType>,
                      engine::mpi::GetType<DType>(), OP::kType, prepare_fun, prepare_arg);
 }
@@ -167,7 +170,8 @@ inline void InvokeLambda_(void *fun) {
   (*static_cast<std::function<void()>*>(fun))();
 }
 template<typename OP, typename DType>
-inline void Allreduce(DType *sendrecvbuf, size_t count, std::function<void()> prepare_fun) {
+inline void Allreduce(DType *sendrecvbuf, size_t count, std::function<void()> prepare_fun, const char* caller) {
+  utils::Printf("[%d] Allreduce caller is %s \n", GetRank(), caller);
   engine::Allreduce_(sendrecvbuf, sizeof(DType), count, op::Reducer<OP, DType>,
                      engine::mpi::GetType<DType>(), OP::kType, InvokeLambda_, &prepare_fun);
 }
@@ -288,7 +292,7 @@ inline Reducer<DType, freduce>::Reducer(void) {
 template<typename DType, void (*freduce)(DType &dst, const DType &src)> // NOLINT(*)
 inline void Reducer<DType, freduce>::Allreduce(DType *sendrecvbuf, size_t count,
                                                void (*prepare_fun)(void *arg),
-                                               void *prepare_arg) {
+                                               void *prepare_arg, const char* caller) {
   handle_.Allreduce(sendrecvbuf, sizeof(DType), count, prepare_fun, prepare_arg);
 }
 // function to perform reduction for SerializeReducer
@@ -337,7 +341,9 @@ template<typename DType>
 inline void SerializeReducer<DType>::Allreduce(DType *sendrecvobj,
                                                size_t max_nbyte, size_t count,
                                                void (*prepare_fun)(void *arg),
-                                               void *prepare_arg) {
+                                               void *prepare_arg,
+                                               const char* caller) {
+  utils::Printf("[%d] Allreduce caller is %s \n", GetRank(), caller);
   buffer_.resize(max_nbyte * count);
   // setup closure
   SerializeReduceClosure<DType> c;
@@ -355,13 +361,17 @@ inline void SerializeReducer<DType>::Allreduce(DType *sendrecvobj,
 #if DMLC_USE_CXX11
 template<typename DType, void (*freduce)(DType &dst, const DType &src)>  // NOLINT(*)g
 inline void Reducer<DType, freduce>::Allreduce(DType *sendrecvbuf, size_t count,
-                                               std::function<void()> prepare_fun) {
+                                               std::function<void()> prepare_fun,
+                                               const char* caller) {
+  utils::Printf("[%d] Allreduce caller is %s \n", GetRank(), caller);
   this->Allreduce(sendrecvbuf, count, InvokeLambda_, &prepare_fun);
 }
 template<typename DType>
 inline void SerializeReducer<DType>::Allreduce(DType *sendrecvobj,
                                                size_t max_nbytes, size_t count,
-                                               std::function<void()> prepare_fun) {
+                                               std::function<void()> prepare_fun,
+                                               const char* caller) {
+  utils::Printf("[%d] Allreduce caller is %s \n", GetRank(), caller);
   this->Allreduce(sendrecvobj, max_nbytes, count, InvokeLambda_, &prepare_fun);
 }
 #endif  // DMLC_USE_CXX11

--- a/include/rabit/internal/rabit-inl.h
+++ b/include/rabit/internal/rabit-inl.h
@@ -142,8 +142,7 @@ inline void Broadcast(std::vector<DType> *sendrecv_data, int root, const char* c
     Broadcast(&(*sendrecv_data)[0], size * sizeof(DType), root, caller);
   }
 }
-inline void Broadcast(std::string *sendrecv_data, int root, 
-  const char* caller) {
+inline void Broadcast(std::string *sendrecv_data, int root, const char* caller) {
   size_t size = sendrecv_data->length();
   Broadcast(&size, sizeof(size), root, caller);
   if (sendrecv_data->length() != size) {
@@ -183,12 +182,12 @@ inline void TrackerPrint(const std::string &msg) {
   engine::GetEngine()->TrackerPrint(msg);
 }
 
-inline void TrackerSetConfig(const std::string &key, const int bsize, const void *value) {
-  engine::GetEngine()->TrackerSetConfig(key, bsize, value);
+inline void TrackerSetConfig(const std::string &key, const std::string &value) {
+  engine::GetEngine()->TrackerSetConfig(key, value);
 }
 
-inline void TrackerGetConfig(const std::string &key, const int bsize, void *value) {
-  engine::GetEngine()->TrackerGetConfig(key, bsize, value);
+inline void TrackerGetConfig(const std::string &key, std::string* value) {
+  engine::GetEngine()->TrackerGetConfig(key, value);
 }
 
 #ifndef RABIT_STRICT_CXX98_
@@ -203,7 +202,7 @@ inline void TrackerPrintf(const char *fmt, ...) {
   TrackerPrint(msg);
 }
 
-inline void TrackerSetConfig(const char *key, const int bsize, const void *value, ...) {
+inline void TrackerSetConfig(const char *key, const char *value, ...) {
   const int kPrintBuffer = 1 << 10;
   std::string k(kPrintBuffer, '\0'), v(kPrintBuffer, '\0');
 
@@ -211,22 +210,28 @@ inline void TrackerSetConfig(const char *key, const int bsize, const void *value
   va_start(args1, key);
   va_start(args2, value);
   vsnprintf(&k[0], kPrintBuffer, key, args1);
+  vsnprintf(&v[0], kPrintBuffer, value, args2);
   va_end(args1);
   va_end(args2);
   k.resize(strlen(k.c_str()));
-  engine::GetEngine()->TrackerSetConfig(k, bsize, value);
+  v.resize(strlen(v.c_str()));
+  engine::GetEngine()->TrackerSetConfig(k, v);
 }
 
-inline void TrackerGetConfig(const char *key, const int bsize, void* value, ...) {
+inline void TrackerGetConfig(const char *key, char* value, ...) {
   const int kPrintBuffer = 1 << 10;
   std::string k(kPrintBuffer, '\0'), v(kPrintBuffer, '\0');
 
-  va_list args1;
+  va_list args1, args2;
   va_start(args1, key);
+  va_start(args2, value);
   vsnprintf(&k[0], kPrintBuffer, key, args1);
+  vsnprintf(&v[0], kPrintBuffer, value, args2);
   va_end(args1);
+  va_end(args2);
   k.resize(strlen(k.c_str()));
-  engine::GetEngine()->TrackerGetConfig(k, bsize, value);
+  v.resize(strlen(v.c_str()));
+  engine::GetEngine()->TrackerGetConfig(k, &v);
 }
 #endif  // RABIT_STRICT_CXX98_
 // load latest check point

--- a/include/rabit/internal/rabit-inl.h
+++ b/include/rabit/internal/rabit-inl.h
@@ -177,6 +177,15 @@ inline void Allreduce(DType *sendrecvbuf, size_t count, std::function<void()> pr
 inline void TrackerPrint(const std::string &msg) {
   engine::GetEngine()->TrackerPrint(msg);
 }
+
+inline void TrackerSetConfig(const std::string &key, const std::string &value) {
+  engine::GetEngine()->TrackerSetConfig(key, value);
+}
+
+inline void TrackerGetConfig(const std::string &key, std::string* value) {
+  engine::GetEngine()->TrackerGetConfig(key, value);
+}
+
 #ifndef RABIT_STRICT_CXX98_
 inline void TrackerPrintf(const char *fmt, ...) {
   const int kPrintBuffer = 1 << 10;

--- a/include/rabit/rabit.h
+++ b/include/rabit/rabit.h
@@ -121,6 +121,18 @@ inline void TrackerGetConfig(const std::string &key, std::string* value);
  * \param fmt the format string
  */
 inline void TrackerPrintf(const char *fmt, ...);
+/*!
+ * \brief save config to tracker,
+ * \param key configuration key
+ * \param value value of config
+ */
+inline void TrackerSetConfig(const char *key, const char *value, ...);
+/*!
+ * \brief get config to tracker,
+ * \param key configuration key
+ * \param value value of config
+ */
+inline void TrackerGetConfig(const char *key, char* value, ...);
 #endif  // RABIT_STRICT_CXX98_
 /*!
  * \brief broadcasts a memory region to every node from the root

--- a/include/rabit/rabit.h
+++ b/include/rabit/rabit.h
@@ -105,13 +105,13 @@ inline void TrackerPrint(const std::string &msg);
  * \param key configuration key
  * \param value value of config
  */
-inline void TrackerSetConfig(const std::string &key, const int bsize, const void* value);
+inline void TrackerSetConfig(const std::string &key, const std::string &value);
 /*!
  * \brief get config to tracker,
  * \param key configuration key
  * \param value value of config
  */
-inline void TrackerGetConfig(const std::string &key, const int bsize, void* value);
+inline void TrackerGetConfig(const std::string &key, std::string* value);
 
 #ifndef RABIT_STRICT_CXX98_
 /*!
@@ -127,13 +127,13 @@ inline void TrackerPrintf(const char *fmt, ...);
  * \param key configuration key
  * \param value value of config
  */
-inline void TrackerSetConfig(const char *key, const int bsize, const void* value, ...);
+inline void TrackerSetConfig(const char *key, const char *value, ...);
 /*!
  * \brief get config to tracker,
  * \param key configuration key
  * \param value value of config
  */
-inline void TrackerGetConfig(const char *key, const int bsize, void* value, ...);
+inline void TrackerGetConfig(const char *key, char* value, ...);
 #endif  // RABIT_STRICT_CXX98_
 /*!
  * \brief broadcasts a memory region to every node from the root
@@ -143,8 +143,7 @@ inline void TrackerGetConfig(const char *key, const int bsize, void* value, ...)
  * \param size the data size
  * \param root the process root
  */
-inline void Broadcast(void *sendrecv_data, size_t size, int root, 
-  const char* caller = __builtin_FUNCTION());
+inline void Broadcast(void *sendrecv_data, size_t size, int root, const char* caller = __builtin_FUNCTION());
 /*!
  * \brief broadcasts an std::vector<DType> to every node from root
  * \param sendrecv_data the pointer to send/receive vector,
@@ -154,16 +153,14 @@ inline void Broadcast(void *sendrecv_data, size_t size, int root,
  *               that can be directly transmitted by sending the sizeof(DType)
  */
 template<typename DType>
-inline void Broadcast(std::vector<DType> *sendrecv_data, int root, 
-  const char* caller = __builtin_FUNCTION());
+inline void Broadcast(std::vector<DType> *sendrecv_data, int root, const char* caller = __builtin_FUNCTION());
 /*!
  * \brief broadcasts a std::string to every node from the root
  * \param sendrecv_data the pointer to the send/receive buffer,
  *        for the receiver, the vector does not need to be pre-allocated
  * \param root the process root
  */
-inline void Broadcast(std::string *sendrecv_data, int root, 
-  const char* caller = __builtin_FUNCTION());
+inline void Broadcast(std::string *sendrecv_data, int root, const char* caller = __builtin_FUNCTION());
 /*!
  * \brief performs in-place Allreduce on sendrecvbuf
  *        this function is NOT thread-safe
@@ -188,8 +185,7 @@ inline void Broadcast(std::string *sendrecv_data, int root,
 template<typename OP, typename DType>
 inline void Allreduce(DType *sendrecvbuf, size_t count,
                       void (*prepare_fun)(void *) = NULL,
-                      void *prepare_arg = NULL, 
-                      const char* caller = __builtin_FUNCTION());
+                      void *prepare_arg = NULL, const char* caller = __builtin_FUNCTION());
 // C++11 support for lambda prepare function
 #if DMLC_USE_CXX11
 /*!
@@ -218,8 +214,7 @@ inline void Allreduce(DType *sendrecvbuf, size_t count,
  */
 template<typename OP, typename DType>
 inline void Allreduce(DType *sendrecvbuf, size_t count,
-                      std::function<void()> prepare_fun, 
-                      const char* caller = __builtin_FUNCTION());
+                      std::function<void()> prepare_fun, const char* caller = __builtin_FUNCTION());
 #endif  // C++11
 /*!
  * \brief loads the latest check point

--- a/include/rabit/rabit.h
+++ b/include/rabit/rabit.h
@@ -99,6 +99,19 @@ inline std::string GetProcessorName();
  * \param msg the message to be printed
  */
 inline void TrackerPrint(const std::string &msg);
+/*!
+ * \brief save config to tracker,
+ * \param key configuration key
+ * \param value value of config
+ */
+inline void TrackerSetConfig(const std::string &key, const std::string &value);
+/*!
+ * \brief get config to tracker,
+ * \param key configuration key
+ * \param value value of config
+ */
+inline void TrackerGetConfig(const std::string &key, std::string* value);
+
 #ifndef RABIT_STRICT_CXX98_
 /*!
  * \brief prints the msg to the tracker, this function may not be available

--- a/include/rabit/rabit.h
+++ b/include/rabit/rabit.h
@@ -12,7 +12,6 @@
 #define RABIT_RABIT_H_  // NOLINT(*)
 #include <string>
 #include <vector>
-#include <cstdio>
 
 // whether or not use c++11 support
 #ifndef DMLC_USE_CXX11
@@ -143,7 +142,7 @@ inline void TrackerGetConfig(const char *key, char* value, ...);
  * \param size the data size
  * \param root the process root
  */
-inline void Broadcast(void *sendrecv_data, size_t size, int root, const char* caller = __builtin_FUNCTION());
+inline void Broadcast(void *sendrecv_data, size_t size, int root);
 /*!
  * \brief broadcasts an std::vector<DType> to every node from root
  * \param sendrecv_data the pointer to send/receive vector,
@@ -153,14 +152,14 @@ inline void Broadcast(void *sendrecv_data, size_t size, int root, const char* ca
  *               that can be directly transmitted by sending the sizeof(DType)
  */
 template<typename DType>
-inline void Broadcast(std::vector<DType> *sendrecv_data, int root, const char* caller = __builtin_FUNCTION());
+inline void Broadcast(std::vector<DType> *sendrecv_data, int root);
 /*!
  * \brief broadcasts a std::string to every node from the root
  * \param sendrecv_data the pointer to the send/receive buffer,
  *        for the receiver, the vector does not need to be pre-allocated
  * \param root the process root
  */
-inline void Broadcast(std::string *sendrecv_data, int root, const char* caller = __builtin_FUNCTION());
+inline void Broadcast(std::string *sendrecv_data, int root);
 /*!
  * \brief performs in-place Allreduce on sendrecvbuf
  *        this function is NOT thread-safe
@@ -185,7 +184,7 @@ inline void Broadcast(std::string *sendrecv_data, int root, const char* caller =
 template<typename OP, typename DType>
 inline void Allreduce(DType *sendrecvbuf, size_t count,
                       void (*prepare_fun)(void *) = NULL,
-                      void *prepare_arg = NULL, const char* caller = __builtin_FUNCTION());
+                      void *prepare_arg = NULL);
 // C++11 support for lambda prepare function
 #if DMLC_USE_CXX11
 /*!
@@ -214,7 +213,7 @@ inline void Allreduce(DType *sendrecvbuf, size_t count,
  */
 template<typename OP, typename DType>
 inline void Allreduce(DType *sendrecvbuf, size_t count,
-                      std::function<void()> prepare_fun, const char* caller = __builtin_FUNCTION());
+                      std::function<void()> prepare_fun);
 #endif  // C++11
 /*!
  * \brief loads the latest check point
@@ -313,7 +312,7 @@ class Reducer {
    */
   inline void Allreduce(DType *sendrecvbuf, size_t count,
                         void (*prepare_fun)(void *) = NULL,
-                        void *prepare_arg = NULL, const char* caller = __builtin_FUNCTION());
+                        void *prepare_arg = NULL);
 #if DMLC_USE_CXX11
   /*!
    * \brief customized in-place all reduce operation, with lambda function as preprocessor
@@ -322,7 +321,7 @@ class Reducer {
    * \param prepare_fun lambda function executed to prepare the data, if necessary
    */
   inline void Allreduce(DType *sendrecvbuf, size_t count,
-                        std::function<void()> prepare_fun, const char* caller = __builtin_FUNCTION());
+                        std::function<void()> prepare_fun);
 #endif  // DMLC_USE_CXX11
 
  private:
@@ -357,7 +356,7 @@ class SerializeReducer {
   inline void Allreduce(DType *sendrecvobj,
                         size_t max_nbyte, size_t count,
                         void (*prepare_fun)(void *) = NULL,
-                        void *prepare_arg = NULL, const char* caller = __builtin_FUNCTION());
+                        void *prepare_arg = NULL);
 // C++11 support for lambda prepare function
 #if DMLC_USE_CXX11
   /*!
@@ -370,7 +369,7 @@ class SerializeReducer {
    */
   inline void Allreduce(DType *sendrecvobj,
                         size_t max_nbyte, size_t count,
-                        std::function<void()> prepare_fun, const char* caller = __builtin_FUNCTION());
+                        std::function<void()> prepare_fun);
 #endif  // DMLC_USE_CXX11
 
  private:

--- a/include/rabit/rabit.h
+++ b/include/rabit/rabit.h
@@ -105,13 +105,13 @@ inline void TrackerPrint(const std::string &msg);
  * \param key configuration key
  * \param value value of config
  */
-inline void TrackerSetConfig(const std::string &key, const std::string &value);
+inline void TrackerSetConfig(const std::string &key, const int bsize, const void* value);
 /*!
  * \brief get config to tracker,
  * \param key configuration key
  * \param value value of config
  */
-inline void TrackerGetConfig(const std::string &key, std::string* value);
+inline void TrackerGetConfig(const std::string &key, const int bsize, void* value);
 
 #ifndef RABIT_STRICT_CXX98_
 /*!
@@ -127,13 +127,13 @@ inline void TrackerPrintf(const char *fmt, ...);
  * \param key configuration key
  * \param value value of config
  */
-inline void TrackerSetConfig(const char *key, const char *value, ...);
+inline void TrackerSetConfig(const char *key, const int bsize, const void* value, ...);
 /*!
  * \brief get config to tracker,
  * \param key configuration key
  * \param value value of config
  */
-inline void TrackerGetConfig(const char *key, char* value, ...);
+inline void TrackerGetConfig(const char *key, const int bsize, void* value, ...);
 #endif  // RABIT_STRICT_CXX98_
 /*!
  * \brief broadcasts a memory region to every node from the root
@@ -143,7 +143,8 @@ inline void TrackerGetConfig(const char *key, char* value, ...);
  * \param size the data size
  * \param root the process root
  */
-inline void Broadcast(void *sendrecv_data, size_t size, int root, const char* caller = __builtin_FUNCTION());
+inline void Broadcast(void *sendrecv_data, size_t size, int root, 
+  const char* caller = __builtin_FUNCTION());
 /*!
  * \brief broadcasts an std::vector<DType> to every node from root
  * \param sendrecv_data the pointer to send/receive vector,
@@ -153,14 +154,16 @@ inline void Broadcast(void *sendrecv_data, size_t size, int root, const char* ca
  *               that can be directly transmitted by sending the sizeof(DType)
  */
 template<typename DType>
-inline void Broadcast(std::vector<DType> *sendrecv_data, int root, const char* caller = __builtin_FUNCTION());
+inline void Broadcast(std::vector<DType> *sendrecv_data, int root, 
+  const char* caller = __builtin_FUNCTION());
 /*!
  * \brief broadcasts a std::string to every node from the root
  * \param sendrecv_data the pointer to the send/receive buffer,
  *        for the receiver, the vector does not need to be pre-allocated
  * \param root the process root
  */
-inline void Broadcast(std::string *sendrecv_data, int root, const char* caller = __builtin_FUNCTION());
+inline void Broadcast(std::string *sendrecv_data, int root, 
+  const char* caller = __builtin_FUNCTION());
 /*!
  * \brief performs in-place Allreduce on sendrecvbuf
  *        this function is NOT thread-safe
@@ -185,7 +188,8 @@ inline void Broadcast(std::string *sendrecv_data, int root, const char* caller =
 template<typename OP, typename DType>
 inline void Allreduce(DType *sendrecvbuf, size_t count,
                       void (*prepare_fun)(void *) = NULL,
-                      void *prepare_arg = NULL, const char* caller = __builtin_FUNCTION());
+                      void *prepare_arg = NULL, 
+                      const char* caller = __builtin_FUNCTION());
 // C++11 support for lambda prepare function
 #if DMLC_USE_CXX11
 /*!
@@ -214,7 +218,8 @@ inline void Allreduce(DType *sendrecvbuf, size_t count,
  */
 template<typename OP, typename DType>
 inline void Allreduce(DType *sendrecvbuf, size_t count,
-                      std::function<void()> prepare_fun, const char* caller = __builtin_FUNCTION());
+                      std::function<void()> prepare_fun, 
+                      const char* caller = __builtin_FUNCTION());
 #endif  // C++11
 /*!
  * \brief loads the latest check point

--- a/include/rabit/rabit.h
+++ b/include/rabit/rabit.h
@@ -12,6 +12,7 @@
 #define RABIT_RABIT_H_  // NOLINT(*)
 #include <string>
 #include <vector>
+#include <cstdio>
 
 // whether or not use c++11 support
 #ifndef DMLC_USE_CXX11
@@ -142,7 +143,7 @@ inline void TrackerGetConfig(const char *key, char* value, ...);
  * \param size the data size
  * \param root the process root
  */
-inline void Broadcast(void *sendrecv_data, size_t size, int root);
+inline void Broadcast(void *sendrecv_data, size_t size, int root, const char* caller = __builtin_FUNCTION());
 /*!
  * \brief broadcasts an std::vector<DType> to every node from root
  * \param sendrecv_data the pointer to send/receive vector,
@@ -152,14 +153,14 @@ inline void Broadcast(void *sendrecv_data, size_t size, int root);
  *               that can be directly transmitted by sending the sizeof(DType)
  */
 template<typename DType>
-inline void Broadcast(std::vector<DType> *sendrecv_data, int root);
+inline void Broadcast(std::vector<DType> *sendrecv_data, int root, const char* caller = __builtin_FUNCTION());
 /*!
  * \brief broadcasts a std::string to every node from the root
  * \param sendrecv_data the pointer to the send/receive buffer,
  *        for the receiver, the vector does not need to be pre-allocated
  * \param root the process root
  */
-inline void Broadcast(std::string *sendrecv_data, int root);
+inline void Broadcast(std::string *sendrecv_data, int root, const char* caller = __builtin_FUNCTION());
 /*!
  * \brief performs in-place Allreduce on sendrecvbuf
  *        this function is NOT thread-safe
@@ -184,7 +185,7 @@ inline void Broadcast(std::string *sendrecv_data, int root);
 template<typename OP, typename DType>
 inline void Allreduce(DType *sendrecvbuf, size_t count,
                       void (*prepare_fun)(void *) = NULL,
-                      void *prepare_arg = NULL);
+                      void *prepare_arg = NULL, const char* caller = __builtin_FUNCTION());
 // C++11 support for lambda prepare function
 #if DMLC_USE_CXX11
 /*!
@@ -213,7 +214,7 @@ inline void Allreduce(DType *sendrecvbuf, size_t count,
  */
 template<typename OP, typename DType>
 inline void Allreduce(DType *sendrecvbuf, size_t count,
-                      std::function<void()> prepare_fun);
+                      std::function<void()> prepare_fun, const char* caller = __builtin_FUNCTION());
 #endif  // C++11
 /*!
  * \brief loads the latest check point
@@ -312,7 +313,7 @@ class Reducer {
    */
   inline void Allreduce(DType *sendrecvbuf, size_t count,
                         void (*prepare_fun)(void *) = NULL,
-                        void *prepare_arg = NULL);
+                        void *prepare_arg = NULL, const char* caller = __builtin_FUNCTION());
 #if DMLC_USE_CXX11
   /*!
    * \brief customized in-place all reduce operation, with lambda function as preprocessor
@@ -321,7 +322,7 @@ class Reducer {
    * \param prepare_fun lambda function executed to prepare the data, if necessary
    */
   inline void Allreduce(DType *sendrecvbuf, size_t count,
-                        std::function<void()> prepare_fun);
+                        std::function<void()> prepare_fun, const char* caller = __builtin_FUNCTION());
 #endif  // DMLC_USE_CXX11
 
  private:
@@ -356,7 +357,7 @@ class SerializeReducer {
   inline void Allreduce(DType *sendrecvobj,
                         size_t max_nbyte, size_t count,
                         void (*prepare_fun)(void *) = NULL,
-                        void *prepare_arg = NULL);
+                        void *prepare_arg = NULL, const char* caller = __builtin_FUNCTION());
 // C++11 support for lambda prepare function
 #if DMLC_USE_CXX11
   /*!
@@ -369,7 +370,7 @@ class SerializeReducer {
    */
   inline void Allreduce(DType *sendrecvobj,
                         size_t max_nbyte, size_t count,
-                        std::function<void()> prepare_fun);
+                        std::function<void()> prepare_fun, const char* caller = __builtin_FUNCTION());
 #endif  // DMLC_USE_CXX11
 
  private:

--- a/scripts/travis_runtest.sh
+++ b/scripts/travis_runtest.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-make -f test.mk model_recover_10_10k || exit -1
-make -f test.mk model_recover_10_10k_die_same  || exit -1
-make -f test.mk model_recover_10_10k_die_hard || exit -1
-make -f test.mk local_recover_10_10k || exit -1
-make -f test.mk lazy_recover_10_10k_die_hard || exit -1
-make -f test.mk lazy_recover_10_10k_die_same || exit -1
-make -f test.mk ringallreduce_10_10k || exit -1
-make -f test.mk pylocal_recover_10_10k || exit -1
+make -f test.mk RABIT_BUILD_DMLC=1 model_recover_10_10k || exit -1
+make -f test.mk RABIT_BUILD_DMLC=1 model_recover_10_10k_die_same  || exit -1
+make -f test.mk RABIT_BUILD_DMLC=1 model_recover_10_10k_die_hard || exit -1
+make -f test.mk RABIT_BUILD_DMLC=1 local_recover_10_10k || exit -1
+make -f test.mk RABIT_BUILD_DMLC=1 lazy_recover_10_10k_die_hard || exit -1
+make -f test.mk RABIT_BUILD_DMLC=1 lazy_recover_10_10k_die_same || exit -1
+make -f test.mk RABIT_BUILD_DMLC=1 ringallreduce_10_10k || exit -1
+make -f test.mk RABIT_BUILD_DMLC=1 pylocal_recover_10_10k || exit -1

--- a/src/allreduce_base.cc
+++ b/src/allreduce_base.cc
@@ -135,6 +135,7 @@ void AllreduceBase::Shutdown(void) {
   sock_listen.Close();
   utils::TCPSocket::Finalize();
 }
+
 void AllreduceBase::TrackerPrint(const std::string &msg) {
   if (tracker_uri == "NULL") {
     utils::Printf("%s", msg.c_str()); return;
@@ -144,6 +145,29 @@ void AllreduceBase::TrackerPrint(const std::string &msg) {
   tracker.SendStr(msg);
   tracker.Close();
 }
+
+void AllreduceBase::TrackerSetConfig(const std::string &key, const std::string &value) {
+  if (tracker_uri == "NULL") {
+    utils::Printf("%s", key.c_str()); return;
+  }
+  utils::TCPSocket tracker = this->ConnectTracker();
+  tracker.SendStr(std::string("set"));
+  tracker.SendStr(key);
+  tracker.SendStr(value);
+  tracker.Close();
+}
+
+void AllreduceBase::TrackerGetConfig(const std::string &key, std::string* value) {
+  if (tracker_uri == "NULL") {
+    utils::Printf("%s", key.c_str()); return;
+  }
+  utils::TCPSocket tracker = this->ConnectTracker();
+  tracker.SendStr(std::string("get"));
+  tracker.SendStr(key);
+  tracker.RecvStr(value);
+  tracker.Close();
+}
+
 // util to parse data with unit suffix
 inline size_t ParseUnit(const char *name, const char *val) {
   char unit;

--- a/src/allreduce_base.cc
+++ b/src/allreduce_base.cc
@@ -146,20 +146,19 @@ void AllreduceBase::TrackerPrint(const std::string &msg) {
   tracker.Close();
 }
 
-void AllreduceBase::TrackerSetConfig(const std::string &key, const int bytesize, const void* value) {
+void AllreduceBase::TrackerSetConfig(const std::string &key, const std::string &value) {
   utils::TCPSocket tracker = this->ConnectTracker();
   tracker.SendStr(std::string("set"));
   tracker.SendStr(key);
-  tracker.Send(&bytesize, sizeof(int));
-  tracker.SendAll(value, bytesize);
+  tracker.SendStr(value);
   tracker.Close();
 }
 
-void AllreduceBase::TrackerGetConfig(const std::string &key, const int bytesize, void* value) {
+void AllreduceBase::TrackerGetConfig(const std::string &key, std::string* value) {
   utils::TCPSocket tracker = this->ConnectTracker();
   tracker.SendStr(std::string("get"));
   tracker.SendStr(key);
-  tracker.RecvAll(value, bytesize);
+  tracker.RecvStr(value);
   tracker.Close();
 }
 

--- a/src/allreduce_base.cc
+++ b/src/allreduce_base.cc
@@ -146,19 +146,20 @@ void AllreduceBase::TrackerPrint(const std::string &msg) {
   tracker.Close();
 }
 
-void AllreduceBase::TrackerSetConfig(const std::string &key, const std::string &value) {
+void AllreduceBase::TrackerSetConfig(const std::string &key, const int bytesize, const void* value) {
   utils::TCPSocket tracker = this->ConnectTracker();
   tracker.SendStr(std::string("set"));
   tracker.SendStr(key);
-  tracker.SendStr(value);
+  tracker.Send(&bytesize, sizeof(int));
+  tracker.SendAll(value, bytesize);
   tracker.Close();
 }
 
-void AllreduceBase::TrackerGetConfig(const std::string &key, std::string* value) {
+void AllreduceBase::TrackerGetConfig(const std::string &key, const int bytesize, void* value) {
   utils::TCPSocket tracker = this->ConnectTracker();
   tracker.SendStr(std::string("get"));
   tracker.SendStr(key);
-  tracker.RecvStr(value);
+  tracker.RecvAll(value, bytesize);
   tracker.Close();
 }
 

--- a/src/allreduce_base.cc
+++ b/src/allreduce_base.cc
@@ -147,9 +147,6 @@ void AllreduceBase::TrackerPrint(const std::string &msg) {
 }
 
 void AllreduceBase::TrackerSetConfig(const std::string &key, const std::string &value) {
-  if (tracker_uri == "NULL") {
-    utils::Printf("%s", key.c_str()); return;
-  }
   utils::TCPSocket tracker = this->ConnectTracker();
   tracker.SendStr(std::string("set"));
   tracker.SendStr(key);
@@ -158,9 +155,6 @@ void AllreduceBase::TrackerSetConfig(const std::string &key, const std::string &
 }
 
 void AllreduceBase::TrackerGetConfig(const std::string &key, std::string* value) {
-  if (tracker_uri == "NULL") {
-    utils::Printf("%s", key.c_str()); return;
-  }
   utils::TCPSocket tracker = this->ConnectTracker();
   tracker.SendStr(std::string("get"));
   tracker.SendStr(key);

--- a/src/allreduce_base.h
+++ b/src/allreduce_base.h
@@ -54,8 +54,8 @@ class AllreduceBase : public IEngine {
    * \param msg message to be printed in the tracker
    */
   virtual void TrackerPrint(const std::string &msg);
-  virtual void TrackerSetConfig(const std::string &key, const std::string &value);
-  virtual void TrackerGetConfig(const std::string& key, std::string* value);
+  virtual void TrackerSetConfig(const std::string &key, const int bytesize, const void* value);
+  virtual void TrackerGetConfig(const std::string &key, const int bytesize, void* value);
 
   /*! \brief get rank */
   virtual int GetRank(void) const {

--- a/src/allreduce_base.h
+++ b/src/allreduce_base.h
@@ -54,6 +54,9 @@ class AllreduceBase : public IEngine {
    * \param msg message to be printed in the tracker
    */
   virtual void TrackerPrint(const std::string &msg);
+  virtual void TrackerSetConfig(const std::string &key, const std::string &value);
+  virtual void TrackerGetConfig(const std::string& key, std::string* value);
+
   /*! \brief get rank */
   virtual int GetRank(void) const {
     return rank;

--- a/src/allreduce_base.h
+++ b/src/allreduce_base.h
@@ -54,8 +54,8 @@ class AllreduceBase : public IEngine {
    * \param msg message to be printed in the tracker
    */
   virtual void TrackerPrint(const std::string &msg);
-  virtual void TrackerSetConfig(const std::string &key, const int bytesize, const void* value);
-  virtual void TrackerGetConfig(const std::string &key, const int bytesize, void* value);
+  virtual void TrackerSetConfig(const std::string &key, const std::string &value);
+  virtual void TrackerGetConfig(const std::string& key, std::string* value);
 
   /*! \brief get rank */
   virtual int GetRank(void) const {

--- a/src/allreduce_robust.cc
+++ b/src/allreduce_robust.cc
@@ -92,6 +92,7 @@ void AllreduceRobust::Allreduce(void *sendrecvbuf_,
     if (prepare_fun != NULL) prepare_fun(prepare_arg);
     return;
   }
+
   bool recovered = RecoverExec(sendrecvbuf_, type_nbytes * count, 0, seq_counter);
   // now we are free to remove the last result, if any
   if (resbuf.LastSeqNo() != -1 &&

--- a/src/allreduce_robust.cc
+++ b/src/allreduce_robust.cc
@@ -298,7 +298,6 @@ void AllreduceRobust::CheckPoint_(const Serializable *global_model,
   if (lazy_checkpt) {
     global_lazycheck = global_model;
   } else {
-    printf("[%d] save global checkpoint #%d \n", this->rank, version_number);
     global_checkpoint.resize(0);
     utils::MemoryBufferStream fs(&global_checkpoint);
     fs.Write(&version_number, sizeof(version_number));

--- a/src/allreduce_robust.cc
+++ b/src/allreduce_robust.cc
@@ -171,7 +171,6 @@ void AllreduceRobust::Broadcast(void *sendrecvbuf_, size_t total_size, int root)
  */
 int AllreduceRobust::LoadCheckPoint(Serializable *global_model,
                                     Serializable *local_model) {
-  
   // skip action in single node
   if (world_size == 1) return 0;
   this->LocalModelCheck(local_model != NULL);
@@ -208,7 +207,8 @@ int AllreduceRobust::LoadCheckPoint(Serializable *global_model,
     // run another phase of check ack, if recovered from data
     utils::Assert(RecoverExec(NULL, 0, ActionSummary::kCheckAck, ActionSummary::kSpecialOp),
                   "check ack must return true");
-    printf("[%d] load checkpoint global %d version %d\n", rank, global_checkpoint.length(), version_number);
+    utils::Printf("[%d] load checkpoint global %ld version %d\n", rank,
+      global_checkpoint.length(), version_number);
     return version_number;
   } else {
     // reset result buffer

--- a/src/allreduce_robust.cc
+++ b/src/allreduce_robust.cc
@@ -92,7 +92,6 @@ void AllreduceRobust::Allreduce(void *sendrecvbuf_,
     if (prepare_fun != NULL) prepare_fun(prepare_arg);
     return;
   }
-
   bool recovered = RecoverExec(sendrecvbuf_, type_nbytes * count, 0, seq_counter);
   // now we are free to remove the last result, if any
   if (resbuf.LastSeqNo() != -1 &&

--- a/src/allreduce_robust.cc
+++ b/src/allreduce_robust.cc
@@ -171,6 +171,7 @@ void AllreduceRobust::Broadcast(void *sendrecvbuf_, size_t total_size, int root)
  */
 int AllreduceRobust::LoadCheckPoint(Serializable *global_model,
                                     Serializable *local_model) {
+  
   // skip action in single node
   if (world_size == 1) return 0;
   this->LocalModelCheck(local_model != NULL);
@@ -207,6 +208,7 @@ int AllreduceRobust::LoadCheckPoint(Serializable *global_model,
     // run another phase of check ack, if recovered from data
     utils::Assert(RecoverExec(NULL, 0, ActionSummary::kCheckAck, ActionSummary::kSpecialOp),
                   "check ack must return true");
+    printf("[%d] load checkpoint global %d version %d\n", rank, global_checkpoint.length(), version_number);
     return version_number;
   } else {
     // reset result buffer
@@ -547,6 +549,7 @@ AllreduceRobust::TryDecideRouting(AllreduceRobust::RecoverType role,
   {
     // get the shortest distance to the request point
     std::vector<std::pair<int, size_t> > dist_in, dist_out;
+
     ReturnType succ = MsgPassing(std::make_pair(role == kHaveData, *p_size),
                                  &dist_in, &dist_out, ShortestDist);
     if (succ != kSuccess) return succ;

--- a/src/allreduce_robust.h
+++ b/src/allreduce_robust.h
@@ -375,6 +375,19 @@ class AllreduceRobust : public AllreduceBase {
    * \sa ReturnType
    */
   ReturnType TryLoadCheckPoint(bool requester);
+
+  /*!
+   * \brief try to load cache
+   *
+   *        This is a collaborative function called by all nodes
+   *        only the nodes with requester set to true really needs to load the check point
+   *        other nodes acts as collaborative roles to complete this request
+   * \param buf the buffer to store the result, this parameter is only used when current node is requester 
+   * \param requester whether current node is the requester
+   * \return this function can return kSuccess/kSockError/kGetExcept, see ReturnType for details
+   * \sa ReturnType
+   */
+  ReturnType TryLoadCache(void *buf, bool requester);
   /*!
    * \brief try to get the result of operation specified by seqno
    *

--- a/src/engine_empty.cc
+++ b/src/engine_empty.cc
@@ -68,6 +68,14 @@ class EmptyEngine : public IEngine {
     // simply print information into the tracker
     utils::Printf("%s", msg.c_str());
   }
+  virtual void TrackerSetConfig(const std::string &key, const std::string &value) {
+    // simply print information into the tracker
+    utils::Printf("%s-%s", key.c_str(), value.c_str());
+  }
+  virtual void TrackerGetConfig(const std::string& key, std::string* value) {
+    // simply print information into the tracker
+    utils::Printf("%s", key.c_str());
+  }
 
  private:
   int version_number;

--- a/src/engine_mpi.cc
+++ b/src/engine_mpi.cc
@@ -77,6 +77,15 @@ class MPIEngine : public IEngine {
       utils::Printf("%s", msg.c_str());
     }
   }
+  virtual void TrackerSetConfig(const std::string &key, const std::string &value) {
+    // simply print information into the tracker
+    // TODO(chen qin): figure out how to support MPI
+    utils::Printf("%s-%s", key.c_str(), value.c_str());
+  }
+  virtual void TrackerGetConfig(const std::string& key, std::string* value) {
+    // simply print information into the tracker
+    utils::Printf("%s", key.c_str());
+  }
 
  private:
   int version_number;

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,14 @@
+RABIT_BUILD_DMLC = 0
+
+ifeq ($(RABIT_BUILD_DMLC),1)
+    DMLC=../dmlc-core
+else
+    DMLC=../../dmlc-core
+endif
+
 MPICXX=../mpich/bin/mpicxx
 export LDFLAGS=  -L../lib -pthread -lm
-export CFLAGS = -Wall -O3 -msse2  -Wno-unknown-pragmas -fPIC -I../include -I ../dmlc-core/include -std=c++11
+export CFLAGS = -Wall -O3 -msse3 -g -Wno-unknown-pragmas -fPIC -I../include -I $(DMLC)/include -std=c++11
 
 OS := $(shell uname)
 

--- a/test/test.mk
+++ b/test/test.mk
@@ -1,3 +1,11 @@
+RABIT_BUILD_DMLC = 0
+
+ifeq ($(RABIT_BUILD_DMLC),1)
+    DMLC=../dmlc-core
+else
+    DMLC=../../dmlc-core
+endif
+
 # this is a makefile used to show testcases of rabit
 .PHONY: all
 
@@ -5,25 +13,25 @@ all: model_recover_10_10k  model_recover_10_10k_die_same model_recover_10_10k_di
 
 # this experiment test recovery with actually process exit, use keepalive to keep program alive
 model_recover_10_10k:
-	../dmlc-core/tracker/dmlc-submit --cluster local --num-workers=10 --local-num-attempt=20 model_recover 10000 mock=0,0,1,0 mock=1,1,1,0
+	$(DMLC)/tracker/dmlc-submit --cluster local --num-workers=10 --local-num-attempt=20 model_recover 10000 mock=0,0,1,0 mock=1,1,1,0
 
 model_recover_10_10k_die_same:
-	../dmlc-core/tracker/dmlc-submit --cluster local --num-workers=10 --local-num-attempt=20 model_recover 10000 mock=0,0,1,0 mock=1,1,1,0 mock=0,1,1,0 mock=4,1,1,0 mock=9,1,1,0
+	$(DMLC)/tracker/dmlc-submit --cluster local --num-workers=10 --local-num-attempt=20 model_recover 10000 mock=0,0,1,0 mock=1,1,1,0 mock=0,1,1,0 mock=4,1,1,0 mock=9,1,1,0
 
 model_recover_10_10k_die_hard:
-	../dmlc-core/tracker/dmlc-submit --cluster local --num-workers=10 --local-num-attempt=20 model_recover 10000 mock=0,0,1,0 mock=1,1,1,0 mock=1,1,1,1 mock=0,1,1,0 mock=4,1,1,0 mock=9,1,1,0 mock=8,1,2,0 mock=4,1,3,0
+	$(DMLC)/tracker/dmlc-submit --cluster local --num-workers=10 --local-num-attempt=20 model_recover 10000 mock=0,0,1,0 mock=1,1,1,0 mock=1,1,1,1 mock=0,1,1,0 mock=4,1,1,0 mock=9,1,1,0 mock=8,1,2,0 mock=4,1,3,0
 
 local_recover_10_10k:
-	../dmlc-core/tracker/dmlc-submit --cluster local --num-workers=10 --local-num-attempt=20 local_recover 10000 mock=0,0,1,0 mock=1,1,1,0 mock=0,1,1,0 mock=4,1,1,0 mock=9,1,1,0 mock=1,1,1,1
+	$(DMLC)/tracker/dmlc-submit --cluster local --num-workers=10 --local-num-attempt=20 local_recover 10000 mock=0,0,1,0 mock=1,1,1,0 mock=0,1,1,0 mock=4,1,1,0 mock=9,1,1,0 mock=1,1,1,1
 
 pylocal_recover_10_10k:
-	../dmlc-core/tracker/dmlc-submit --cluster local --num-workers=10 --local-num-attempt=20 local_recover.py 10000 mock=0,0,1,0 mock=1,1,1,0 mock=0,1,1,0 mock=4,1,1,0 mock=9,1,1,0 mock=1,1,1,1
+	$(DMLC)/tracker/dmlc-submit --cluster local --num-workers=10 --local-num-attempt=20 local_recover.py 10000 mock=0,0,1,0 mock=1,1,1,0 mock=0,1,1,0 mock=4,1,1,0 mock=9,1,1,0 mock=1,1,1,1
 
 lazy_recover_10_10k_die_hard:
-	../dmlc-core/tracker/dmlc-submit --cluster local --num-workers=10 --local-num-attempt=20 lazy_recover 10000 mock=0,0,1,0 mock=1,1,1,0 mock=1,1,1,1 mock=0,1,1,0 mock=4,1,1,0 mock=9,1,1,0 mock=8,1,2,0 mock=4,1,3,0
+	$(DMLC)/tracker/dmlc-submit --cluster local --num-workers=10 --local-num-attempt=20 lazy_recover 10000 mock=0,0,1,0 mock=1,1,1,0 mock=1,1,1,1 mock=0,1,1,0 mock=4,1,1,0 mock=9,1,1,0 mock=8,1,2,0 mock=4,1,3,0
 
 lazy_recover_10_10k_die_same:
-	../dmlc-core/tracker/dmlc-submit --cluster local --num-workers=10 --local-num-attempt=20 lazy_recover 10000 mock=0,0,1,0 mock=1,1,1,0 mock=0,1,1,0 mock=4,1,1,0 mock=9,1,1,0
+	$(DMLC)/tracker/dmlc-submit --cluster local --num-workers=10 --local-num-attempt=20 lazy_recover 10000 mock=0,0,1,0 mock=1,1,1,0 mock=0,1,1,0 mock=4,1,1,0 mock=9,1,1,0
 
 ringallreduce_10_10k:
-	../dmlc-core/tracker/dmlc-submit --cluster local --num-workers=10 model_recover 10000 rabit_reduce_ring_mincount=10
+	$(DMLC)/tracker/dmlc-submit --cluster local --num-workers=10 model_recover 10000 rabit_reduce_ring_mincount=10


### PR DESCRIPTION
native rabit checkpoint restore were failing in XGB. 

In order to let restart worker avoid run allreduce before loadcheckpoint, we plan to save those config(s) in dmlc-tracker when training job starts first time(e.g number of columns of partitioned training data set)

If worker failure, instead of calling allreduce and break rabit recovery assumption, we can fetch configs from tracker. This would allow checkpoint load correctly and starts at right iteration number.  

If tracker die, training job will die anyway. We might leverage spark hdfs checkpoint and recover entire cluster from there.

More detail here
https://github.com/dmlc/xgboost/issues/4250#issuecomment-501023606
