### PR TITLE
allowing shutdown for multiple times

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -57,14 +57,16 @@ bool Init(int argc, char *argv[]) {
 /*! \brief finalize syncrhonization module */
 bool Finalize() {
   ThreadLocalEntry* e = EngineThreadLocal::Get();
-  utils::Check(e->engine.get() != nullptr,
-               "rabit::Finalize engine is not initialized or already been finalized.");
-  if (e->engine->Shutdown()) {
-    e->engine.reset(nullptr);
-    e->initialized = false;
-    return true;
+  if (e->engine.get() != nullptr) {
+    if (e->engine->Shutdown()) {
+      e->engine.reset(nullptr);
+      e->initialized = false;
+      return true;
+    } else {
+      return false;
+    }
   } else {
-    return false;
+    return true;
   }
 }
 


### PR DESCRIPTION
it doesn't hurt for allowing finalize running for multiple times and there is a classic scenario requiring these 

for example 

```scala
val df1 = xgbmodel.transform(training)
val df2 = xgbmodel2.transform(df1)
```

because we shutdown rabit in both of df1 and df2 the current code explicitly prohibit such usage pattern, 

