### PR TITLE
Fix compilation failure on Windows

### DIFF
--- a/include/rabit/internal/utils.h
+++ b/include/rabit/internal/utils.h
@@ -66,7 +66,7 @@ const int kPrintBuffer = 1 << 12;
 /*! \brief we may want to keep the process alive when there are multiple workers
  * co-locate in the same process */
 extern bool STOP_PROCESS_ON_ERROR;
-  
+
 /* \brief Case-insensitive string comparison */
 inline int CompareStringsCaseInsensitive(const char* s1, const char* s2) {
 #ifdef _MSC_VER

--- a/include/rabit/internal/utils.h
+++ b/include/rabit/internal/utils.h
@@ -66,10 +66,19 @@ const int kPrintBuffer = 1 << 12;
 /*! \brief we may want to keep the process alive when there are multiple workers
  * co-locate in the same process */
 extern bool STOP_PROCESS_ON_ERROR;
+  
+/* \brief Case-insensitive string comparison */
+inline int CompareStringsCaseInsensitive(const char* s1, const char* s2) {
+#ifdef _MSC_VER
+  return _stricmp(s1, s2);
+#else  // _MSC_VER
+  return strcasecmp(s1, s2);
+#endif  // _MSC_VER
+}
 
 /* \brief parse config string too bool*/
 inline bool StringToBool(const char* s) {
-  return strcasecmp(s, "true") == 0 || atoi(s) != 0;
+  return CompareStringsCaseInsensitive(s, "true") == 0 || atoi(s) != 0;
 }
 
 #ifndef RABIT_CUSTOMIZE_MSG_


### PR DESCRIPTION
`strcasecmp` is POSIX so does not exist on Windows. Use `_stricmp` instead. This is the cause of the compilation failure in https://xgboost-ci.net/blue/organizations/jenkins/xgboost-win64/detail/PR-4876/50/pipeline#step-44-log-401

@trivialfis @chenqin 