### PR TITLE
throw dmlc::Error 

### DIFF
--- a/include/rabit/internal/utils.h
+++ b/include/rabit/internal/utils.h
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include <stdexcept>
 #include <vector>
+#include "dmlc/io.h"
 
 #ifndef RABIT_STRICT_CXX98_
 #include <cstdarg>
@@ -83,7 +84,7 @@ inline void HandleAssertError(const char *msg) {
     exit(-1);
   } else {
     fprintf(stderr, "AssertError:%s, rabit is configured to keep process running\n", msg);
-    throw std::runtime_error(msg);
+    throw dmlc::Error(msg);
   }
 }
 /*!
@@ -96,7 +97,7 @@ inline void HandleCheckError(const char *msg) {
     exit(-1);
   } else {
     fprintf(stderr, "%s, rabit is configured to keep process running\n", msg);
-    throw std::runtime_error(msg);
+    throw dmlc::Error(msg);
   }
 }
 inline void HandlePrint(const char *msg) {

--- a/include/rabit/serializable.h
+++ b/include/rabit/serializable.h
@@ -10,10 +10,6 @@
 #include <string>
 #include "rabit/internal/utils.h"
 
-#ifndef DMLC_IO_H_
-#include "dmlc/io.h"
-#endif  // DMLC_IO_H_
-
 namespace rabit {
 /*!
  * \brief defines stream used in rabit

--- a/src/allreduce_base.cc
+++ b/src/allreduce_base.cc
@@ -219,7 +219,7 @@ void AllreduceBase::SetParam(const char *name, const char *val) {
   }
   if (!strcmp(name, "rabit_timeout_sec")) {
     timeout_sec = atoi(val);
-    utils::Assert(rabit_timeout > 0, "rabit_timeout_sec should be greater than 0 second");
+    utils::Assert(timeout_sec > 0, "rabit_timeout_sec should be greater than 0 second");
   }
 }
 /*!


### PR DESCRIPTION
XGBoost JNI only handles dmlc::Error from try catch clause, replace std::runtime_error with dmlc::Error could allow us gracefully handle rabit worker assertion errors and propagated to jvm layer

https://github.com/dmlc/xgboost/blob/master/src/c_api/c_api_error.h#L17
![image](https://user-images.githubusercontent.com/1184534/66941727-6530ba00-effc-11e9-9ca0-b997182a3894.png)

![image](https://user-images.githubusercontent.com/1184534/66859521-5a185400-ef40-11e9-92ad-2274a032ebfd.png)


@CodingCat @trivialfis @hcho3 