### PR TITLE
Fix gtest include

### DIFF
--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(
   rabit_base rabit_mock rabit)
 
 target_include_directories(unit_tests PUBLIC
+   ${GTEST_INCLUDE_DIRS}
   "$<BUILD_INTERFACE:${rabit_SOURCE_DIR}/include>"
   "$<BUILD_INTERFACE:${DMLC_ROOT}/include>")
 


### PR DESCRIPTION
The unit tests currently do not include the Gtest headers leading to compilation failure.