### PR TITLE
allow duplicated bootstrap allreduce overwrite previous results

### DIFF
--- a/src/allreduce_robust.cc
+++ b/src/allreduce_robust.cc
@@ -108,7 +108,9 @@ int AllreduceRobust::SetBootstrapCache(const std::string &key, const void *buf,
       break;
     }
   }
-  _assert(index == -1, "immutable cache key already exists");
+  // we should consider way to support duplicated signatures
+  // https://github.com/dmlc/xgboost/issues/5012
+  // _assert(index == -1, "immutable cache key already exists");
   _assert(type_nbytes*count > 0, "can't set empty cache");
   void* temp = cachebuf.AllocTemp(type_nbytes, count);
   cachebuf.PushTemp(cur_cache_seq, type_nbytes, count);


### PR DESCRIPTION
Rabit assume bootstrap allreduce has unique signature, in https://github.com/dmlc/xgboost/issues/5012 we find it failed to satisfy such constraint. 

The goal of this pr is to loosen such constraint and allow last write overwrite results with same signature during bootstrap phase. Here is example https://github.com/dmlc/xgboost/pull/4990/files#diff-5fabd019d3f1af7572baa4a6301cf076R36



