### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/allreduce_robust.cc
+++ b/src/allreduce_robust.cc
@@ -19,6 +19,8 @@
 #include "rabit/internal/rabit-inl.h"
 #include "allreduce_robust.h"
 
+#undef _assert
+
 namespace rabit {
 namespace engine {
 


### PR DESCRIPTION
Ensures that Rabit can be compiled on FreeBSD platform.

Details: the `assert.h` header in FreeBSD defines the macro `_assert`, which clashes with the internal field `_assert` of `AllreduceRobust`.

Closes #131