### PR TITLE
Use 'default' visibility for C symbols

### DIFF
--- a/include/rabit/c_api.h
+++ b/include/rabit/c_api.h
@@ -18,7 +18,7 @@
 #if defined(_MSC_VER) || defined(_WIN32)
 #define RABIT_DLL RABIT_EXTERN_C __declspec(dllexport)
 #else
-#define RABIT_DLL RABIT_EXTERN_C
+#define RABIT_DLL RABIT_EXTERN_C __attribute__ ((visibility ("default")))
 #endif  // defined(_MSC_VER) || defined(_WIN32)
 
 /*! \brief rabit unsigned long type */


### PR DESCRIPTION
This is useful when we want to hide all C++ symbols but keep C symbols visible. With this change, we can apply `-fvisibility=hidden` compiler flag everywhere and keep C symbols visible.

cc @trivialfis 