### PR TITLE
remove inaccurate comment in rabit.py

### DIFF
--- a/python/rabit.py
+++ b/python/rabit.py
@@ -43,7 +43,6 @@ def _find_lib_path(dll_name):
             'List of candidates:\n' + ('\n'.join(dll_path)))
     return lib_path
 
-# load in xgboost library
 def _loadlib(lib='standard', lib_dll=None):
     """Load rabit library."""
     global _LIB


### PR DESCRIPTION
I was reading through the `rabit` source code today and saw this comment that looks out of place: https://github.com/dmlc/rabit/blob/4acdd7c6f68debe1c39ae07ca75466d74d194dd1/python/rabit.py#L46

I think it was probably accidentally copied over from `xgboost`.